### PR TITLE
Add --mysqld.socket option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,7 +86,7 @@ func (ch *MySqlConfigHandler) GetConfig() *Config {
 	return ch.Config
 }
 
-func (ch *MySqlConfigHandler) ReloadConfig(filename string, mysqldAddress string, mysqldUser string, tlsInsecureSkipVerify bool, logger log.Logger) error {
+func (ch *MySqlConfigHandler) ReloadConfig(filename, mysqldAddress, mysqldSocket, mysqldUser string, tlsInsecureSkipVerify bool, logger log.Logger) error {
 	var host, port string
 	defer func() {
 		if err != nil {
@@ -115,6 +115,9 @@ func (ch *MySqlConfigHandler) ReloadConfig(filename string, mysqldAddress string
 		}
 		if cfgPort := clientSection.Key("port"); cfgPort.String() == "" {
 			cfgPort.SetValue(port)
+		}
+		if cfgSocket := clientSection.Key("socket"); cfgSocket.String() == "" {
+			cfgSocket.SetValue(mysqldSocket)
 		}
 		if cfgUser := clientSection.Key("user"); cfgUser.String() == "" {
 			cfgUser.SetValue(mysqldUser)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,7 +28,7 @@ func TestValidateConfig(t *testing.T) {
 		c := MySqlConfigHandler{
 			Config: &Config{},
 		}
-		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", true, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", "", true, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 
@@ -60,7 +60,7 @@ func TestValidateConfig(t *testing.T) {
 		c := MySqlConfigHandler{
 			Config: &Config{},
 		}
-		if err := c.ReloadConfig("testdata/child_client.cnf", "localhost:3306", "", true, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/child_client.cnf", "localhost:3306", "", "", true, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 		cfg := c.GetConfig()
@@ -73,7 +73,7 @@ func TestValidateConfig(t *testing.T) {
 			Config: &Config{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
-		if err := c.ReloadConfig("", "testhost:5000", "testuser", true, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("", "testhost:5000", "/test.sock", "testuser", true, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 
@@ -81,6 +81,7 @@ func TestValidateConfig(t *testing.T) {
 		section := cfg.Sections["client"]
 		convey.So(section.Host, convey.ShouldEqual, "testhost")
 		convey.So(section.Port, convey.ShouldEqual, 5000)
+		convey.So(section.Socket, convey.ShouldEqual, "/test.sock")
 		convey.So(section.User, convey.ShouldEqual, "testuser")
 		convey.So(section.Password, convey.ShouldEqual, "supersecretpassword")
 	})
@@ -90,7 +91,7 @@ func TestValidateConfig(t *testing.T) {
 			Config: &Config{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
-		err := c.ReloadConfig("", "testhost", "testuser", true, log.NewNopLogger())
+		err := c.ReloadConfig("", "testhost", "", "testuser", true, log.NewNopLogger())
 		convey.So(
 			err,
 			convey.ShouldBeError,
@@ -102,7 +103,7 @@ func TestValidateConfig(t *testing.T) {
 			Config: &Config{},
 		}
 		os.Setenv("MYSQLD_EXPORTER_PASSWORD", "supersecretpassword")
-		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "fakeuser", true, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", "fakeuser", true, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 
@@ -117,7 +118,7 @@ func TestValidateConfig(t *testing.T) {
 			Config: &Config{},
 		}
 		os.Clearenv()
-		err := c.ReloadConfig("testdata/missing_user.cnf", "localhost:3306", "", true, log.NewNopLogger())
+		err := c.ReloadConfig("testdata/missing_user.cnf", "localhost:3306", "", "", true, log.NewNopLogger())
 		convey.So(
 			err,
 			convey.ShouldResemble,
@@ -130,7 +131,7 @@ func TestValidateConfig(t *testing.T) {
 			Config: &Config{},
 		}
 		os.Clearenv()
-		if err := c.ReloadConfig("testdata/missing_password.cnf", "localhost:3306", "", true, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/missing_password.cnf", "localhost:3306", "", "", true, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 
@@ -151,7 +152,7 @@ func TestFormDSN(t *testing.T) {
 	)
 
 	convey.Convey("Host exporter dsn", t, func() {
-		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", false, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", "", false, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 		convey.Convey("Default Client", func() {
@@ -191,7 +192,7 @@ func TestFormDSNWithSslSkipVerify(t *testing.T) {
 	)
 
 	convey.Convey("Host exporter dsn with tls skip verify", t, func() {
-		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", true, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/client.cnf", "localhost:3306", "", "", true, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 		convey.Convey("Default Client", func() {
@@ -223,7 +224,7 @@ func TestFormDSNWithCustomTls(t *testing.T) {
 	)
 
 	convey.Convey("Host exporter dsn with custom tls", t, func() {
-		if err := c.ReloadConfig("testdata/client_custom_tls.cnf", "localhost:3306", "", false, log.NewNopLogger()); err != nil {
+		if err := c.ReloadConfig("testdata/client_custom_tls.cnf", "localhost:3306", "", "", false, log.NewNopLogger()); err != nil {
 			t.Error(err)
 		}
 		convey.Convey("Target tls enabled", func() {

--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -54,6 +54,10 @@ var (
 		"mysqld.address",
 		"Address to use for connecting to MySQL",
 	).Default("localhost:3306").String()
+	mysqldSocket = kingpin.Flag(
+		"mysqld.socket",
+		"Unix-domain socket to use for connecting to MySQL",
+	).String()
 	mysqldUser = kingpin.Flag(
 		"mysqld.username",
 		"Hostname to use for connecting to MySQL",
@@ -241,7 +245,7 @@ func main() {
 	level.Info(logger).Log("msg", "Build context", "build_context", version.BuildContext())
 
 	var err error
-	if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {
+	if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldSocket, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {
 		level.Info(logger).Log("msg", "Error parsing host config", "file", *configMycnf, "err", err)
 		os.Exit(1)
 	}
@@ -284,7 +288,7 @@ func main() {
 	http.HandleFunc("/probe", handleProbe(enabledScrapers, logger))
 	http.Handle("/-/extras", extras)
 	http.HandleFunc("/-/reload", func(w http.ResponseWriter, r *http.Request) {
-		if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {
+		if err = c.ReloadConfig(*configMycnf, *mysqldAddress, *mysqldSocket, *mysqldUser, *tlsInsecureSkipVerify, logger); err != nil {
 			level.Warn(logger).Log("msg", "Error reloading host config", "file", *configMycnf, "error", err)
 			return
 		}


### PR DESCRIPTION
When DATA_SOURCE_NAME was removed it became impossible to configure mysqld_exporter to connect to MySQL via a socket without resorting to a my.cnf file.

This patch adds `--mysqld.socket` as an alternative to `--mysqld.address` and accompaniment to `--mysqld.username`. We expect it to be used in lieu of `--config.my-cnf`.