### PR TITLE
Add curl and jq for vttablet-preStop.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,10 @@ RUN rm -f /mysqld_exporter/mysqld_exporter
 RUN CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" make -C /mysqld_exporter build
 
 FROM golang:alpine
+RUN apk --no-cache add curl
+RUN apk --no-cache add jq
 COPY --from=build /mysqld_exporter/mysqld_exporter /bin/mysqld_exporter
 EXPOSE 9104
 USER nobody
+WORKDIR /
 ENTRYPOINT ["/bin/mysqld_exporter"]


### PR DESCRIPTION
We (definitely) need `curl` and (ideally) `jq`, too, in order to do our in-place tablet-rolling via `vttablet-preStop.sh`. So this patch adds `curl` and `jq` to the `mysqld_exporter` container image.

Here's a live container from before this patch:

    █ acre:~/src/planetscale/mysqld_exporter % pskr -n user-data exec
    vttablet-aws-uswest2a-5-2398428221-2f828e4c -c mysqld-exporter -- which
    which
    /usr/bin/which
    █ acre:~/src/planetscale/mysqld_exporter % pskr -n user-data exec
    vttablet-aws-uswest2a-5-2398428221-2f828e4c -c mysqld-exporter -- which
    curl
    command terminated with exit code 1
    █ acre:~/src/planetscale/mysqld_exporter % pskr -n user-data exec
    vttablet-aws-uswest2a-5-2398428221-2f828e4c -c mysqld-exporter -- which
    jq
    command terminated with exit code 1
    █ acre:~/src/planetscale/mysqld_exporter %

And here's a new container with this patch:

    █ acre:~/src/planetscale/mysqld_exporter % docker buildx build -t
    mysqld_exporter:test .
    ...
    █ acre:~/src/planetscale/mysqld_exporter % docker run --entrypoint which
    -i -t mysqld_exporter:test which
    /usr/bin/which
    █ acre:~/src/planetscale/mysqld_exporter % docker run --entrypoint which
    -i -t mysqld_exporter:test curl
    /usr/bin/curl
    █ acre:~/src/planetscale/mysqld_exporter % docker run --entrypoint which
    -i -t mysqld_exporter:test jq
    /usr/bin/jq
    █ acre:~/src/planetscale/mysqld_exporter %