### PR TITLE
ci(gha): enable arm64 docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,19 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=sha
 
+      # setup qemu and buildx for cross-builds (arm64)
+      - name: Set up QEMU (for arm64 builds)
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
       - id: push
         name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           labels: ${{ steps.meta.outputs.labels }}
-          #platforms: linux/amd64,linux/arm64 # TODO support ARM, too, with this and a different "driver"
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
build and tested both arch's from a branch:

arm64:
```console
$ docker run --rm -it --pull=always ghcr.io/planetscale/mysqld_exporter:sha-b349467@sha256:8bbf2031e33d154b81c7965afed490ed0d9596aadc5879c8d280fb2496894b10 

Status: Downloaded newer image for ghcr.io/planetscale/mysqld_exporter@sha256:8bbf2031e33d154b81c7965afed490ed0d9596aadc5879c8d280fb2496894b10
ts=2024-09-16T15:05:30.974Z caller=mysqld_exporter.go:244 level=info msg="Starting mysqld_exporter" version="(version=0.15.1, branch=joem/ci-arm64, revision=b349467c2148734546be93882ccfb97c3b74cd79)"
ts=2024-09-16T15:05:30.974Z caller=mysqld_exporter.go:245 level=info msg="Build context" build_context="(go=go1.23.1, platform=linux/arm64, user=root@buildkitsandbox, date=20240916-15:03:47, tags=unknown)"
```

amd64:

```console
$ docker run --rm -it --pull=always ghcr.io/planetscale/mysqld_exporter:sha-b349467@sha256:8bbf2031e33d154b81c7965afed490ed0d9596aadc5879c8d280fb2496894b10 

Digest: sha256:8bbf2031e33d154b81c7965afed490ed0d9596aadc5879c8d280fb2496894b10
Status: Downloaded newer image for ghcr.io/planetscale/mysqld_exporter@sha256:8bbf2031e33d154b81c7965afed490ed0d9596aadc5879c8d280fb2496894b10
ts=2024-09-16T15:05:17.516Z caller=mysqld_exporter.go:244 level=info msg="Starting mysqld_exporter" version="(version=0.15.1, branch=joem/ci-arm64, revision=b349467c2148734546be93882ccfb97c3b74cd79)"
ts=2024-09-16T15:05:17.516Z caller=mysqld_exporter.go:245 level=info msg="Build context" build_context="(go=go1.23.1, platform=linux/amd64, user=root@buildkitsandbox, date=20240916-15:03:47, tags=unknown)"
```