### PR TITLE
docker: switch to wolfi base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM --platform=$BUILDPLATFORM golang:bookworm AS build
+FROM --platform=$BUILDPLATFORM pscale.dev/wolfi-prod/go:1.23 AS build
 ARG TARGETOS
 ARG TARGETARCH
-RUN apt-get -y install make
+RUN apk --no-cache add curl
 COPY . /mysqld_exporter
 RUN rm -f /mysqld_exporter/mysqld_exporter
 RUN CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" make -C /mysqld_exporter build
 
-FROM golang:alpine
-RUN apk --no-cache add curl
-RUN apk --no-cache add jq
+FROM pscale.dev/wolfi-prod/base:latest
+RUN apk --no-cache add curl jq
 COPY --from=build /mysqld_exporter/mysqld_exporter /bin/mysqld_exporter
 EXPOSE 9104
 USER nobody


### PR DESCRIPTION
standardize on our wolfi os images, and reduce final image size from 250 -> 50 MB